### PR TITLE
Downgrade requirement to php to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^5.6",
         "composer-plugin-api": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
As we don't necessary need 7.0, maybe 5.6 ?