### PR TITLE
Skip dev-master packages

### DIFF
--- a/src/Command/MakeStableCommand.php
+++ b/src/Command/MakeStableCommand.php
@@ -49,12 +49,20 @@ class MakeStableCommand extends BaseCommand {
 			$composerJson = $composerFile->read();
 			if ( isset( $composerJson['require'] ) ) {
 				foreach ( $composerJson['require'] as $package => $version ) {
+					if ( 'dev-master' === $composerJson['require'][ $package ] ) {
+						continue;
+					}
+
 					$composerJson['require'][ $package ] = $this->stable;
 				}
 			}
 
 			if ( isset( $composerJson['require-dev'] ) ) {
 				foreach ( $composerJson['require-dev'] as $package => $version ) {
+					if ( 'dev-master' === $composerJson['require-dev'][ $package ] ) {
+						continue;
+					}
+
 					$composerJson['require-dev'][ $package ] = $this->stable;
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please provide tests, if you can.
-->

This pull request should fix BeAPI/composer-freeze-version/issues/3.

Before this change, the command would set all packages's versions to `*@stable`.

Now it will skip any packages using `dev-master` as version.

This should be an ok fix for now but we might need to do more robust checks in the future.